### PR TITLE
Fix German translations

### DIFF
--- a/Localizable-widget.xcstrings
+++ b/Localizable-widget.xcstrings
@@ -205,7 +205,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Befehl der Fernbedienung"
+            "value" : "Fernbedienung"
           }
         },
         "fr" : {
@@ -227,7 +227,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entität der Fernbedienun"
+            "value" : "Befehl der Fernbedienung"
           }
         },
         "fr" : {
@@ -249,7 +249,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fernbedienung-Entität"
+            "value" : "Entität der Fernbedienung"
           }
         },
         "fr" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2667,7 +2667,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Wirt",
+            "value": "Host",
             "state": "translated"
           }
         },
@@ -3177,7 +3177,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Nome",
+            "value": "Name",
             "state": "translated"
           }
         },
@@ -3755,7 +3755,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Hafen",
+            "value": "Port",
             "state": "translated"
           }
         },
@@ -3994,7 +3994,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Fernbedienung 2 %@",
+            "value": "Remote 2 %@",
             "state": "translated"
           }
         },
@@ -4028,7 +4028,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Fernbedienung 3 %@",
+            "value": "Remote 3 %@",
             "state": "translated"
           }
         },
@@ -5321,7 +5321,7 @@
         },
         "de": {
           "stringUnit": {
-            "value": "Ausführung%@",
+            "value": "Version %@",
             "state": "translated"
           }
         },


### PR DESCRIPTION
Another other user has used a translation tool for their translation and also "added" translations in other languages. These strings were deliberately the same word as in English but have been translated too. This was also casing issues with proper names like for the remote model names. I fixed all German strings. There may be strings on other languages that also have to be fixed.