### PR TITLE
Add Spanish translation for remote connection message

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2800,6 +2800,12 @@
             "state" : "translated",
             "value" : "Activer la connexion permanente à toutes les télécommandes enregistrées"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar conexión permanente en todos los mandos registrados"
+          }
         }
       }
     },


### PR DESCRIPTION
Missing 1 Spanish Label.

There are other that is missing for Translation "All services" if you can add it would be perfect. spanish translation will be "Todos los servicios".